### PR TITLE
Fix typo: HeadQuaters → Headquarters in FactionForm placeholder

### DIFF
--- a/X4SectorCreator/Forms/Factions/FactionForm.Designer.cs
+++ b/X4SectorCreator/Forms/Factions/FactionForm.Designer.cs
@@ -314,7 +314,7 @@
             // 
             TxtPreferredHqSpace.Location = new Point(430, 214);
             TxtPreferredHqSpace.Name = "TxtPreferredHqSpace";
-            TxtPreferredHqSpace.PlaceholderText = "Select Preferred HeadQuaters";
+            TxtPreferredHqSpace.PlaceholderText = "Select Preferred Headquarters";
             TxtPreferredHqSpace.ReadOnly = true;
             TxtPreferredHqSpace.Size = new Size(197, 23);
             TxtPreferredHqSpace.TabIndex = 18;


### PR DESCRIPTION
Fix a simple typo in a user-facing GUI placeholder text.

**Before:** `Select Preferred HeadQuaters`
**After:** `Select Preferred Headquarters`

**File:** `X4SectorCreator/Forms/Factions/FactionForm.Designer.cs` line 317

The placeholder text shown in the Preferred HQ selection field had a misspelling.